### PR TITLE
Removed leading / of install paths

### DIFF
--- a/pkg/config/CMakeLists.txt
+++ b/pkg/config/CMakeLists.txt
@@ -11,5 +11,5 @@ set(DNBD3_CONFIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/alt-servers
 
 # install configuration files into sample directory
 install(FILES ${DNBD3_CONFIG_FILES}
-        DESTINATION /etc/dnbd3-server/sample
+        DESTINATION etc/dnbd3-server/sample
         COMPONENT server)

--- a/pkg/systemd/CMakeLists.txt
+++ b/pkg/systemd/CMakeLists.txt
@@ -9,5 +9,5 @@ set(DNBD3_SYSTEMD_FILES ${CMAKE_CURRENT_SOURCE_DIR}/dnbd3-server.service)
 
 # install systemd service files
 install(FILES ${DNBD3_SYSTEMD_FILES}
-        DESTINATION /usr/lib/systemd/system
+        DESTINATION usr/lib/systemd/system
         COMPONENT server)


### PR DESCRIPTION
Removed leading / of install paths, so files get installed in the directory requested by CMake's --prefix.